### PR TITLE
suggesties voor Metadatastandaard

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -173,13 +173,6 @@
         "description": "Is er een data protection impact assessment (DPIA) uitgevoerd?",
         "required": false
       },
-      "DPIA_description": {
-        "name": "Omschrijving van de DPIA",
-        "category": "JURIDISCH",
-        "type": "string",
-        "description": "Een overzicht van de belangrijkste zaken die uit de data protection impact assessment (DPIA) naar voren kwamen.",
-        "required": false
-      },
       "objection_procedure": {
         "name": "Bezwaarprocedure",
         "category": "JURIDISCH",

--- a/schema.json
+++ b/schema.json
@@ -219,7 +219,7 @@
         "name": "Taal",
         "category": "METADATA",
         "type": "string",
-        "description": "De taal waarin deze registratie is ingevoerd.",
+        "description": "De taal waarin deze registratie is ingevoerd, volgens ISO-standaard.",
         "required": false
       },
       "revision_date": {

--- a/schema.json
+++ b/schema.json
@@ -228,6 +228,13 @@
         "type": "string",
         "description": "Termen gerelateerd aan dit algoritme.",
         "required": false
+      },
+      "link_processing_register": {
+        "name": "Link naar verwerkingsregister",
+        "category": "METADATA",
+        "type": "string",
+        "description": "Indien van toepassing, de link naar de AVG-verwerking van het algoritme",
+        "required": false
       }
     }
   }

--- a/schema.json
+++ b/schema.json
@@ -212,7 +212,7 @@
         "name": "Geografisch gebied",
         "category": "METADATA",
         "type": "string",
-        "description": "Het geografische gebied waarin het algoritme wordt ingezet.",
+        "description": "Het geografische gebied waarin het algoritme wordt ingezet, met geodata.",
         "required": false
       },
       "lang": {

--- a/schema.json
+++ b/schema.json
@@ -82,13 +82,6 @@
         "description": "Een afweging van de voor- en nadelen van de inzet van het algoritme en waarom dit redelijk gerechtvaardigd is.",
         "required": true
       },
-      "decision_making_process": {
-        "name": "Proces",
-        "category": "INZET",
-        "type": "string",
-        "description": "De naam van het bedrijfs- of besluitvormingsproces in de organisatie waarbinnen het algoritme wordt ingezet.",
-        "required": true
-      },
       "description": {
         "name": "Omschrijving",
         "category": "TOEPASSING",

--- a/schema.json
+++ b/schema.json
@@ -159,13 +159,6 @@
         "description": "Een omschrijving van de verwachte prestaties van het algoritme en hoe die worden gemeten.",
         "required": false
       },
-      "competent_authority": {
-        "name": "Bevoegde autoriteit",
-        "category": "JURIDISCH",
-        "type": "string",
-        "description": "Volledige naam van de bevoegde autoriteit verantwoordelijk voor de inzet van het algoritme.",
-        "required": false
-      },
       "lawful_basis": {
         "name": "Wettelijke grondslag",
         "category": "JURIDISCH",

--- a/schema.json
+++ b/schema.json
@@ -16,7 +16,7 @@
         "name": "Organisatie",
         "category": "ALGEMENE INFORMATIE",
         "type": "string",
-        "description": "De volledige naam van de organisatie verantwoordelijk voor de inzet van het algoritme.",
+        "description": "De volledige naam van de organisatie verantwoordelijk voor de inzet van het algoritme. Kan linken naar de organisatieregistratie op organisaties.overheid.nl",
         "required": true
       },
       "department": {

--- a/schema.json
+++ b/schema.json
@@ -191,7 +191,7 @@
         "name": "UUID",
         "category": "METADATA",
         "type": "string",
-        "description": "De unieke identificatie (UUID) voor deze registratie.",
+        "description": "De unieke identificatiecode (UUID) voor deze registratie.",
         "required": false
       },
       "url": {

--- a/schema.json
+++ b/schema.json
@@ -165,6 +165,13 @@
         "type": "boolean",
         "description": "Is er een data protection impact assessment (DPIA) uitgevoerd?",
         "required": false
+      },      
+      "human_rights": {
+        "name": "Mensenrechtentoets",
+        "category": "JURIDISCH",
+        "type": "string",
+        "description": "Is er een mensenrechtentoets uitgevoerd, zoals een IAMA? Indien deze online beschikbaar is, linkt dit veld naar de publicatie.",
+        "required": false
       },
       "objection_procedure": {
         "name": "Bezwaarprocedure",

--- a/schema.json
+++ b/schema.json
@@ -221,6 +221,13 @@
         "type": "string",
         "description": "De datum waarvoor deze registratie moet worden herzien.",
         "required": false
+      },
+      "tags": {
+        "name": "Tags",
+        "category": "METADATA",
+        "type": "string",
+        "description": "Termen gerelateerd aan dit algoritme.",
+        "required": false
       }
     }
   }

--- a/schema.json
+++ b/schema.json
@@ -89,13 +89,6 @@
         "description": "De naam van het bedrijfs- of besluitvormingsproces in de organisatie waarbinnen het algoritme wordt ingezet.",
         "required": true
       },
-      "documentation": {
-        "name": "Projectpagina",
-        "category": "INZET",
-        "type": "string",
-        "description": "URL van de projectpagina van de organisatie zelf over dit specifieke gebruik van het algoritme.",
-        "required": false
-      },
       "description": {
         "name": "Omschrijving",
         "category": "TOEPASSING",

--- a/schema.json
+++ b/schema.json
@@ -117,6 +117,13 @@
         "description": "Standaard methoden of modellen die het algoritme gebruikt.",
         "required": false
       },
+      "provider": {
+        "name": "Leverancier",
+        "category": "TOEPASSING",
+        "type": "string",
+        "description": "Indien van toepassing, de derde partij die het algoritme heeft geproduceerd.",
+        "required": false
+      },
       "monitoring": {
         "name": "Monitoring",
         "category": "TOEZICHT",

--- a/schema.json
+++ b/schema.json
@@ -110,13 +110,6 @@
         "description": "URL van de code base van het algoritme.",
         "required": false
       },
-      "MPRD": {
-        "name": "Koppelingen met basisregistraties",
-        "category": "TOEPASSING",
-        "type": "boolean",
-        "description": "Is het algoritme direct gekoppeld aan een basisregistratie?",
-        "required": false
-      },
       "source_data": {
         "name": "Brondata",
         "category": "TOEPASSING",


### PR DESCRIPTION
Voor de volgende versie van de metadatastandaard is ons voorstel om de volgende wijzigingen aan te brengen. Deze willen wij op korte termijn delen met overheidsorganisaties, met maatschappelijke partijen en via [Pleio](https://algoritmes.pleio.nl/groups/view/e5dd717e-8817-44e7-893f-cd6bcfa2d24f/metadatastandaard) of hier. Zij krijgen ruimte om feedback te geven, waarna wij nog aanpassingen aan dit voorstel doen. 

Uitgangspunt van deze wijziging is dat het relatief oncontroversieel moet zijn en niet tot een significante verzwaring van de uitvoerbaarheid moet leiden. Voorstellen die daar niet aan voldoen, kunnen in een latere wijziging aangebracht worden, waar meer tijd voor genomen kan worden. Input daarvoor wordt ook op korte termijn gevraagd. 

Netto: 4 toevoegingen, 5 verwijderingen, 4 functionele aanpassingen.