### PR TITLE
Make "publiccode" required and always show the field.

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -303,11 +303,11 @@
       "type": "string",
       "title": "Link naar broncode",
       "max_length": 500,
-      "show_always": false,
+      "show_always": true,
       "help_text": "Een URL naar de codepagina van de ontwikkelaar. Op deze pagina kunt u meer vinden over de code van het algoritme zelf.",
       "instructions": "Een URL naar de codepagina van de ontwikkelaar. Op deze pagina is de code van het algoritme te vinden. Indien er geen codebase publiekelijk beschikbaar is, dient dit veld leeg te blijven. Begin een URL met https://",
       "example": "https://github.com/haakssoftwarebedrijf.nl/vrisoftware",
-      "required": false
+      "required": true
     },
     "human_intervention": {
       "type": "string",


### PR DESCRIPTION
In line with the position paper from the College voor de Rechten van de Mens: Make is visible when transparency about the detailed logic behind the algorithm isn't available. And because intellectual property may not be an obstacle to this transparency I suggest making this field required as well. Under exceptional circumstances this linkt could also link to a resource that's (partially) redacted.