### PR TITLE
Verhelder de omschrijving bij veld "Link naar broncode"

### DIFF
--- a/schema.json
+++ b/schema.json
@@ -296,8 +296,8 @@
             "type": "string",
             "format": "uri",
             "display": "optional",
-            "description": "Een URL naar de codepagina van de ontwikkelaar. Op deze pagina is de code van het algoritme te vinden. Indien er geen codebase publiekelijk beschikbaar is, dient dit veld leeg te blijven.",
-            "instructions": "Een URL naar de codepagina van de ontwikkelaar. Op deze pagina is de code van het algoritme te vinden. Indien er geen codebase publiekelijk beschikbaar is, dient dit veld leeg te blijven. Begin een URL met https://",
+            "description": "Een URL die verwijst naar de codepagina waarop de broncode van het algoritme openbaar beschikbaar is.",
+            "instructions": "Een URL die verwijst naar de codepagina waarop de broncode van het algoritme openbaar beschikbaar is. Indien er geen codebase publiekelijk beschikbaar is, dient dit veld leeg te blijven. Ook verwijzingen naar de leverancier van een algoritme die de broncode niet openbaar beschikbaar stelt horen niet in dit veld thuis. Begin een URL met https://",
             "example": "https://github.com/haakssoftwarebedrijf/vrisoftware"
         },
         "language": {


### PR DESCRIPTION
Naar aanleiding van o.a de discussie op Pleio: https://algoritmes.pleio.nl/groups/view/e5dd717e-8817-44e7-893f-cd6bcfa2d24f/publicatiestandaard/questions/view/d1131aad-66e7-4e23-9e09-2cde94487aba/transparantie-broncode-afgezwakt