### PR TITLE
Geen impacttoetsen noemen als niet bekend is of die er zijn.

### DIFF
--- a/backend/app/data/templates/1.0/DataMask.json
+++ b/backend/app/data/templates/1.0/DataMask.json
@@ -38,14 +38,6 @@
     ],
     "iama_description": null,
     "impacttoetsen_grouping": [
-      {
-        "title": "DEDA anonimiseringssoftware",
-        "link": ""
-      },
-      {
-        "title": "DPIA anonimiseringssoftware",
-        "link": ""
-      }
     ],
     "url": null,
     "lang": "NLD",

--- a/backend/app/data/templates/1.0/PinkRoccade.json
+++ b/backend/app/data/templates/1.0/PinkRoccade.json
@@ -94,9 +94,8 @@
         "link": "https://wetten.overheid.nl/BWBR0002638/2024-07-01"
       }
     ],
-    "impacttoetsen": "<p>DPIA is toegepast.</p>",
+    "impacttoetsen": "",
     "impacttoetsen_grouping": [
-      { "title": "Data Protection Impact Assessment (DPIA)", "link": null }
     ],
     "iama_description": null,
     "url": null,

--- a/backend/app/data/templates/1.0/Xxllnc.json
+++ b/backend/app/data/templates/1.0/Xxllnc.json
@@ -38,14 +38,6 @@
     ],
     "iama_description": null,
     "impacttoetsen_grouping": [
-      {
-        "title": "DEDA anonimiseringssoftware",
-        "link": ""
-      },
-      {
-        "title": "DPIA anonimiseringssoftware",
-        "link": ""
-      }
     ],
     "url": null,
     "lang": "NLD",


### PR DESCRIPTION
Enkele templates gaan er vanuit dat er impacttoetsen zijn uitgevoerd, zonder te linken naar een beschikbare generieke impacttoets die ook hergebruikt kan worden of al duidelijk van toepassing is. Mijn ervaring leert dat bij navraag bij registraties waarin staat dat impacttoetsen zijn uitgevoerd dat die vaak niet daadwerkelijk beschikbaar zijn. Ik denk dat het veiliger is om er in de template niet vanuit te gaan dat impacttoetsen zijn uitgevoerd.
